### PR TITLE
Add selector to Deployment spec in helm templates

### DIFF
--- a/hello-cloudbuild/k8s/demo/templates/deployment.yaml
+++ b/hello-cloudbuild/k8s/demo/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ .Values.container.name }}
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.container.name }}
   template:
     metadata:
       labels:

--- a/hello-drone/k8s/demo/templates/deployment.yaml
+++ b/hello-drone/k8s/demo/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ .Values.container.name }}
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.container.name }}
   template:
     metadata:
       labels:

--- a/hello-helm/k8s/demo/templates/deployment.yaml
+++ b/hello-helm/k8s/demo/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ .Values.container.name }}
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.container.name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
As @tobinus pointed out in https://github.com/cloudnativedevops/demo/issues/16 the newer Deployments are failing when installing with helm with the following error:

```
Error: release demo failed: Deployment.apps "demo" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"app":"demo", "environment":"development"}: `selector` does not match template `labels`]
```

This PR adds the missing `selector` section.