### PR TITLE
deprecated from k8s 1.25

### DIFF
--- a/hello-helm/helm-auth.yaml
+++ b/hello-helm/helm-auth.yaml
@@ -5,7 +5,7 @@ metadata:
   name: tiller
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tiller


### PR DESCRIPTION
RuntimeClass in the node.k8s.io/v1beta1 API version will no longer be served in v1.25.
   Migrate manifests and API clients to use the node.k8s.io/v1 API version, available since v1.20.