### PR TITLE
Helm install usage update

### DIFF
--- a/hello-helm3/README.md
+++ b/hello-helm3/README.md
@@ -45,7 +45,7 @@ kubectl delete all --selector app=demo
 Then run the following command:
 
 ```
-helm install --name demo ./k8s/demo
+helm install demo ./k8s/demo
 NAME:   demo
 LAST DEPLOYED: Wed Jun  6 10:48:50 2018
 NAMESPACE: default


### PR DESCRIPTION
In the part of about helm you write: helm install --name demo ./k8s/demo. But now new helm install usage is as follow helm install [NAME] [CHART] [flags] and command should look like this helm install demo ./k8s/demo