### PR TITLE
Fix Replicas error in overlay folder

### DIFF
--- a/hello-kustomize/demo/overlays/dev/replicas.yaml
+++ b/hello-kustomize/demo/overlays/dev/replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: 2


### PR DESCRIPTION
kubectl apply -k overlays/dev/

fails because replicas.yaml is not present.
Error:
```
paths:
- replicas.yaml `: evalsymlink failure on '/home/mmootz/code/k8s/demo/hello-kustomize/demo/overlays/dev/replicas.yaml' : lstat /home/mmootz/code/k8s/demo/hello-kustomize/demo/overlays/dev/replicas.yaml: no such file or directory
```